### PR TITLE
Fixed bug in gryo property

### DIFF
--- a/adafruit_lsm9ds1.py
+++ b/adafruit_lsm9ds1.py
@@ -316,7 +316,7 @@ class LSM9DS1:
         """The gyroscope X, Y, Z axis values as a 3-tuple of
         degrees/second values.
         """
-        raw = self.read_mag_raw()
+        raw = self.read_gyro_raw()
         return map(lambda x: x * self._gyro_dps_digit, raw)
 
     def read_temp_raw(self):


### PR DESCRIPTION
The gyro property now returns the gyroscope measurement instead of the magnetometer measurement.