### PR TITLE
added option to change I2C address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bundles
 .eggs
 dist
 **/*.egg-info
+.vscode/settings.json

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,31 @@ Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
 
+Installing from PyPI
+=====================
+
+On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
+PyPI <https://pypi.org/project/adafruit-circuitpython-lsm9ds1/>`_. To install for current user:
+
+.. code-block:: shell
+
+    pip3 install adafruit-circuitpython-lsm9ds1
+
+To install system-wide (this may be required in some cases):
+
+.. code-block:: shell
+
+    sudo pip3 install adafruit-circuitpython-lsm9ds1
+
+To install in a virtual environment in your current project:
+
+.. code-block:: shell
+
+    mkdir project-name && cd project-name
+    python3 -m venv .env
+    source .env/bin/activate
+    pip3 install adafruit-circuitpython-lsm9ds1
+
 Usage Example
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -27,22 +27,6 @@ Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
 
-Installing from PyPI
-=====================
-
-On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
-PyPI <https://pypi.org/project/adafruit-circuitpython-lsm9ds1/>`_. To install for current user:
-
-.. code-block:: shell
-
-    pip3 install adafruit-circuitpython-lsm9ds1
-
-To install system-wide (this may be required in some cases):
-
-.. code-block:: shell
-
-    sudo pip3 install adafruit-circuitpython-lsm9ds1
-
 Usage Example
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -43,15 +43,6 @@ To install system-wide (this may be required in some cases):
 
     sudo pip3 install adafruit-circuitpython-lsm9ds1
 
-To install in a virtual environment in your current project:
-
-.. code-block:: shell
-
-    mkdir project-name && cd project-name
-    python3 -m venv .env
-    source .env/bin/activate
-    pip3 install adafruit-circuitpython-lsm9ds1
-
 Usage Example
 =============
 

--- a/adafruit_lsm9ds1.py
+++ b/adafruit_lsm9ds1.py
@@ -363,12 +363,24 @@ class LSM9DS1:
 
 
 class LSM9DS1_I2C(LSM9DS1):
-    """Driver for the LSM9DS1 connect over I2C."""
+    """Driver for the LSM9DS1 connect over I2C.
 
-    def __init__(self, i2c):
-        self._mag_device = i2c_device.I2CDevice(i2c, _LSM9DS1_ADDRESS_MAG)
-        self._xg_device = i2c_device.I2CDevice(i2c, _LSM9DS1_ADDRESS_ACCELGYRO)
-        super().__init__()
+    :param ~busio.I2C i2c: The I2C bus object used to connect to the LSM9DS1.
+
+        .. note:: This object should be shared among other driver classes that use the same I2C bus (SDA & SCL pins) to connect to different I2C devices.
+
+    :param int mag_address: A 16-bit integer that represents the i2c address of the LSM9DS1's magnetometer. Options are limited to ``0x1C`` or ``0x1E``. Defaults to ``0x1E``.
+    :param int xg_address: A 16-bit integer that represents the i2c address of the LSM9DS1's accelerometer and gyroscope. Options are limited to ``0x6A`` or ``0x6B``. Defaults to ``0x6B``.
+
+    """
+
+    def __init__(self, i2c, mag_address=_LSM9DS1_ADDRESS_MAG, xg_address=_LSM9DS1_ADDRESS_ACCELGYRO):
+        if mag_address in (0x1c, 0x1e) and xg_address in (0x6a, 0x6b):
+            self._mag_device = i2c_device.I2CDevice(i2c, mag_address)
+            self._xg_device = i2c_device.I2CDevice(i2c, xg_address)
+            super().__init__()
+        else:
+            raise ValueError('address parmeters are incorrect. Read the docs at https://circuitpython.readthedocs.io/projects/lsm9ds1/en/latest/api.html#adafruit_lsm9ds1.LSM9DS1_I2C')
 
     def _read_u8(self, sensor_type, address):
         if sensor_type == _MAGTYPE:
@@ -401,7 +413,16 @@ class LSM9DS1_I2C(LSM9DS1):
 
 
 class LSM9DS1_SPI(LSM9DS1):
-    """Driver for the LSM9DS1 connect over SPI."""
+    """Driver for the LSM9DS1 connect over SPI.
+
+    :param ~busio.SPI spi: The SPI bus object used to connect to the LSM9DS1.
+
+        .. note:: This object should be shared among other driver classes that use the same SPI bus (SCK, MISO, MOSI pins) to connect to different SPI devices.
+
+    :param ~digitalio.DigitalInOut mcs: The digital output pin connected to the LSM9DS1's CSM (Chip Select Magnetometer) pin.
+    :param ~digitalio.DigitalInOut xgcs: The digital output pin connected to the LSM9DS1's CSAG (Chip Select Accelerometer/Gyroscope) pin.
+
+    """
     # pylint: disable=no-member
     def __init__(self, spi, xgcs, mcs):
         self._mag_device = spi_device.SPIDevice(spi, mcs, baudrate=200000, phase=1, polarity=1)

--- a/adafruit_lsm9ds1.py
+++ b/adafruit_lsm9ds1.py
@@ -368,25 +368,27 @@ class LSM9DS1_I2C(LSM9DS1):
     :param ~busio.I2C i2c: The I2C bus object used to connect to the LSM9DS1.
 
         .. note:: This object should be shared among other driver classes that use the
-        same I2C bus (SDA & SCL pins) to connect to different I2C devices.
+            same I2C bus (SDA & SCL pins) to connect to different I2C devices.
 
     :param int mag_address: A 16-bit integer that represents the i2c address of the
-    LSM9DS1's magnetometer. Options are limited to ``0x1C`` or ``0x1E``.
-    Defaults to ``0x1E``.
+        LSM9DS1's magnetometer. Options are limited to ``0x1C`` or ``0x1E``.
+        Defaults to ``0x1E``.
+
     :param int xg_address: A 16-bit integer that represents the i2c address of the
-    LSM9DS1's accelerometer and gyroscope. Options are limited to ``0x6A`` or ``0x6B``.
-    Defaults to ``0x6B``.
+        LSM9DS1's accelerometer and gyroscope. Options are limited to ``0x6A`` or ``0x6B``.
+        Defaults to ``0x6B``.
 
     """
-
-    def __init__(self, i2c, mag_address=_LSM9DS1_ADDRESS_MAG, xg_address=_LSM9DS1_ADDRESS_ACCELGYRO):
+    def __init__(self, i2c, mag_address=_LSM9DS1_ADDRESS_MAG,
+                 xg_address=_LSM9DS1_ADDRESS_ACCELGYRO):
         if mag_address in (0x1c, 0x1e) and xg_address in (0x6a, 0x6b):
             self._mag_device = i2c_device.I2CDevice(i2c, mag_address)
             self._xg_device = i2c_device.I2CDevice(i2c, xg_address)
             super().__init__()
         else:
             raise ValueError('address parmeters are incorrect. Read the docs at '
-                             'https://circuitpython.rtfd.io/projects/lsm9ds1/en/latest/api.html#adafruit_lsm9ds1.LSM9DS1_I2C')
+                             'circuitpython.rtfd.io/projects/lsm9ds1/en/latest'
+                             '/api.html#adafruit_lsm9ds1.LSM9DS1_I2C')
 
     def _read_u8(self, sensor_type, address):
         if sensor_type == _MAGTYPE:
@@ -424,12 +426,13 @@ class LSM9DS1_SPI(LSM9DS1):
     :param ~busio.SPI spi: The SPI bus object used to connect to the LSM9DS1.
 
         .. note:: This object should be shared among other driver classes that use the
-        same SPI bus (SCK, MISO, MOSI pins) to connect to different SPI devices.
+            same SPI bus (SCK, MISO, MOSI pins) to connect to different SPI devices.
 
     :param ~digitalio.DigitalInOut mcs: The digital output pin connected to the
-    LSM9DS1's CSM (Chip Select Magnetometer) pin.
+        LSM9DS1's CSM (Chip Select Magnetometer) pin.
+
     :param ~digitalio.DigitalInOut xgcs: The digital output pin connected to the
-    LSM9DS1's CSAG (Chip Select Accelerometer/Gyroscope) pin.
+        LSM9DS1's CSAG (Chip Select Accelerometer/Gyroscope) pin.
 
     """
     # pylint: disable=no-member

--- a/adafruit_lsm9ds1.py
+++ b/adafruit_lsm9ds1.py
@@ -370,11 +370,11 @@ class LSM9DS1_I2C(LSM9DS1):
         .. note:: This object should be shared among other driver classes that use the
             same I2C bus (SDA & SCL pins) to connect to different I2C devices.
 
-    :param int mag_address: A 16-bit integer that represents the i2c address of the
+    :param int mag_address: A 8-bit integer that represents the i2c address of the
         LSM9DS1's magnetometer. Options are limited to ``0x1C`` or ``0x1E``.
         Defaults to ``0x1E``.
 
-    :param int xg_address: A 16-bit integer that represents the i2c address of the
+    :param int xg_address: A 8-bit integer that represents the i2c address of the
         LSM9DS1's accelerometer and gyroscope. Options are limited to ``0x6A`` or ``0x6B``.
         Defaults to ``0x6B``.
 

--- a/adafruit_lsm9ds1.py
+++ b/adafruit_lsm9ds1.py
@@ -367,10 +367,15 @@ class LSM9DS1_I2C(LSM9DS1):
 
     :param ~busio.I2C i2c: The I2C bus object used to connect to the LSM9DS1.
 
-        .. note:: This object should be shared among other driver classes that use the same I2C bus (SDA & SCL pins) to connect to different I2C devices.
+        .. note:: This object should be shared among other driver classes that use the
+        same I2C bus (SDA & SCL pins) to connect to different I2C devices.
 
-    :param int mag_address: A 16-bit integer that represents the i2c address of the LSM9DS1's magnetometer. Options are limited to ``0x1C`` or ``0x1E``. Defaults to ``0x1E``.
-    :param int xg_address: A 16-bit integer that represents the i2c address of the LSM9DS1's accelerometer and gyroscope. Options are limited to ``0x6A`` or ``0x6B``. Defaults to ``0x6B``.
+    :param int mag_address: A 16-bit integer that represents the i2c address of the
+    LSM9DS1's magnetometer. Options are limited to ``0x1C`` or ``0x1E``.
+    Defaults to ``0x1E``.
+    :param int xg_address: A 16-bit integer that represents the i2c address of the
+    LSM9DS1's accelerometer and gyroscope. Options are limited to ``0x6A`` or ``0x6B``.
+    Defaults to ``0x6B``.
 
     """
 
@@ -380,7 +385,8 @@ class LSM9DS1_I2C(LSM9DS1):
             self._xg_device = i2c_device.I2CDevice(i2c, xg_address)
             super().__init__()
         else:
-            raise ValueError('address parmeters are incorrect. Read the docs at https://circuitpython.readthedocs.io/projects/lsm9ds1/en/latest/api.html#adafruit_lsm9ds1.LSM9DS1_I2C')
+            raise ValueError('address parmeters are incorrect. Read the docs at '
+                             'https://circuitpython.rtfd.io/projects/lsm9ds1/en/latest/api.html#adafruit_lsm9ds1.LSM9DS1_I2C')
 
     def _read_u8(self, sensor_type, address):
         if sensor_type == _MAGTYPE:
@@ -417,10 +423,13 @@ class LSM9DS1_SPI(LSM9DS1):
 
     :param ~busio.SPI spi: The SPI bus object used to connect to the LSM9DS1.
 
-        .. note:: This object should be shared among other driver classes that use the same SPI bus (SCK, MISO, MOSI pins) to connect to different SPI devices.
+        .. note:: This object should be shared among other driver classes that use the
+        same SPI bus (SCK, MISO, MOSI pins) to connect to different SPI devices.
 
-    :param ~digitalio.DigitalInOut mcs: The digital output pin connected to the LSM9DS1's CSM (Chip Select Magnetometer) pin.
-    :param ~digitalio.DigitalInOut xgcs: The digital output pin connected to the LSM9DS1's CSAG (Chip Select Accelerometer/Gyroscope) pin.
+    :param ~digitalio.DigitalInOut mcs: The digital output pin connected to the
+    LSM9DS1's CSM (Chip Select Magnetometer) pin.
+    :param ~digitalio.DigitalInOut xgcs: The digital output pin connected to the
+    LSM9DS1's CSAG (Chip Select Accelerometer/Gyroscope) pin.
 
     """
     # pylint: disable=no-member


### PR DESCRIPTION
- LSM9DS1_I2C class now accepts alternate addresses via the constructor's parameters.
- implemented I2C address checking to ensure proper functionality when specifying mag_address & xg_address parameters.
- LSM9DS1_I2C & LSM9DS1_SPI classes' docs now have an explanation of what their constructor's parameters are.

~~added missing information in README about how to install on Raspberry Pi~~  reverted readme to its original state.